### PR TITLE
Add app_version and item_version in update_url

### DIFF
--- a/chrome/content/extensions.rdf
+++ b/chrome/content/extensions.rdf
@@ -6,7 +6,7 @@
   xmlns:NC="http://home.netscape.com/NC-rdf#">
   <!-- Make sure to change the updateURL for your environment --!>
   <Seq about="http://inverse.ca/sogo-integrator/extensions"
-    isi:updateURL="http://sogohostname/path/to/updates.php?plugin=%ITEM_ID%&amp;version=%ITEM_VERSION%&amp;platform=%PLATFORM%">
+    isi:updateURL="http://sogohostname/path/to/updates.php?app_version=%APP_VERSION%&amp;plugin=%ITEM_ID%&amp;version=%ITEM_VERSION%&amp;platform=%PLATFORM%">
 
 <!--  <li>
       <Description

--- a/chrome/content/messenger/startup-overlay.js
+++ b/chrome/content/messenger/startup-overlay.js
@@ -27,6 +27,11 @@ let appInfo = Components.classes["@mozilla.org/xre/app-info;1"]
                         .getService(Components.interfaces.nsIXULRuntime);
 let platformId = appInfo.OS + "_" + appInfo.XPCOMABI;
 
+let xulAppInfo = Components.classes["@mozilla.org/xre/app-info;1"]
+    .getService(Components.interfaces.nsIXULAppInfo);
+
+let appVersion = xulAppInfo.version;
+
 function checkExtensionsUpdate() {
     let extensionInfos = getHandledExtensions();
     let extensions = extensionInfos["extensions"];
@@ -96,9 +101,10 @@ function getHandledExtensions() {
     return extensionInfos;
 }
 
-function makeExtensionURL(baseURL, extension) {
-    let replaceDict = { "%ITEM_ID%": escape(extension.id),
-                        "%ITEM_VERSION%": "0.00",
+function makeExtensionURL(baseURL, extension, extensionItem) {
+    let replaceDict = { "%APP_VERSION%": escape (appVersion),
+                        "%ITEM_ID%": escape(extension.id),
+                        "%ITEM_VERSION%": escape(extensionItem ? extensionItem.version : "0.00"),
                         "%PLATFORM%": escape(platformId) };
 
     let url = baseURL;
@@ -124,7 +130,7 @@ function prepareRequiredExtensions(extensionInfos, extensionItems) {
 
     let rdf = iCc["@mozilla.org/rdf/rdf-service;1"].getService(iCi.nsIRDFService);
     for (let i = 0; i < extensions.length; i++) {
-        let url = makeExtensionURL(extensionInfos["updateRDF"], extensions[i]);
+        let url = makeExtensionURL(extensionInfos["updateRDF"], extensions[i], extensionItems[i]);
         let extensionURN = rdf.GetResource("urn:mozilla:extension:" + extensions[i].id);
         let extensionData = getExtensionData(rdf, url, extensionURN);
         if (extensionData) {


### PR DESCRIPTION
Hi,

In startup-overlay.js ITEM_VERSION is present but always fixed to "0.00". Additionally, APP_VERSION is not sent to update url : we used to deploy integrator on very heterogeneous machine pool, and app_version is required.

I don't know if pull request on git hub is the right war to do that, nor if my code is perfect (we use it in production).
